### PR TITLE
Stop unsetting user variable EUPS_PKGROOT.

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -6,7 +6,7 @@
 
 
 # clean/backup existing EUPS environment variable
-for var in EUPS_PATH EUPS_SHELL SETUP_EUPS EUPS_DIR EUPS_PKGROOT; do
+for var in EUPS_PATH EUPS_SHELL SETUP_EUPS EUPS_DIR; do
   if [[ "${!var}" ]]; then
     export CONDA_EUPS_BACKUP_${var}="${!var}"
   fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [win]
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
It is not appropriate for activation to manipulate this variable, as it is a user preference setting, not something that the `eups` package should control.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
