### PR TITLE
Improve activate/deactivate scripts, including making them strictly POSIX-compatible.

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -7,13 +7,15 @@
 
 
 # clean/backup existing EUPS environment variable
-for var in EUPS_PATH EUPS_SHELL SETUP_EUPS EUPS_DIR; do
-  eval "value=\"\${$var}\""
-  if [ -n "${value}" ]; then
-    export CONDA_EUPS_BACKUP_${var}="${value}"
+for __eups_var in EUPS_PATH EUPS_SHELL SETUP_EUPS EUPS_DIR; do
+  eval "__eups_value=\"\${$__eups_var}\""
+  if [ -n "${__eups_value}" ]; then
+    export CONDA_EUPS_BACKUP_${__eups_var}="${__eups_value}"
   fi
-  unset $var
+  unset $__eups_var
 done
+unset __eups_value
+unset __eups_var
 # shellcheck disable=SC2155,SC3044
 export CONDA_EUPS_BACKUP_setup="$(declare -f setup 2>/dev/null)"
 unset -f setup 2>/dev/null || true

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=sh
 # Bootstrap EUPS
 #
 # Derived from the stackvana-core recipe by Matt Becker (GitHub @beckermr)
@@ -13,12 +14,14 @@ for var in EUPS_PATH EUPS_SHELL SETUP_EUPS EUPS_DIR; do
   fi
   unset $var
 done
-export CONDA_EUPS_BACKUP_setup="`declare -f setup`"
+# shellcheck disable=SC2155,SC3044
+export CONDA_EUPS_BACKUP_setup="$(declare -f setup 2>/dev/null)"
 unset -f setup 2>/dev/null || true
 if [ -z "$CONDA_EUPS_BACKUP_setup" ]; then
   unset CONDA_EUPS_BACKUP_setup
 fi
-export CONDA_EUPS_BACKUP_unsetup="`declare -f unsetup`"
+# shellcheck disable=SC2155,SC3044
+export CONDA_EUPS_BACKUP_unsetup="$(declare -f unsetup 2>/dev/null)"
 unset -f unsetup 2>/dev/null || true
 if [ -z "$CONDA_EUPS_BACKUP_unsetup" ]; then
   unset CONDA_EUPS_BACKUP_unsetup
@@ -33,9 +36,12 @@ fi
 
 # initializing eups
 EUPS_DIR="${CONDA_PREFIX}/eups"
+# shellcheck disable=SC1091
 . "${EUPS_DIR}/bin/setups.sh"
 if [ -n "${BASH}" ]; then
+  # shellcheck disable=SC3045
   export -f setup
+  # shellcheck disable=SC3045
   export -f unsetup
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,7 +13,7 @@ export EUPS_PATH="${PREFIX}/share/eups"
 
 
 EUPS_PYTHON=$PYTHON  # use PYTHON in the host env for eups
-mkdir -p ${EUPS_HOME}
+mkdir -p "${EUPS_HOME}"
 
 
 # Install EUPS
@@ -37,16 +37,16 @@ chmod -R u+w "${EUPS_DIR}"
 
 
 # turn off eups locking
-echo "hooks.config.site.lockDirectoryBase = None" >> ${EUPS_DIR}/site/startup.py
+echo "hooks.config.site.lockDirectoryBase = None" >> "${EUPS_DIR}/site/startup.py"
 
 # make eups use a sane path to python in scripts
 # the long line causes failures on linux
 for fname in "eups" "eups_setup"; do
-    cp ${EUPS_DIR}/bin/${fname} ${EUPS_DIR}/bin/${fname}.bak
-    echo "#!/usr/bin/env python" > ${EUPS_DIR}/bin/${fname}
-    tail -n +1 ${EUPS_DIR}/bin/${fname}.bak >> ${EUPS_DIR}/bin/${fname}
-    chmod 755 ${EUPS_DIR}/bin/${fname}
-    rm ${EUPS_DIR}/bin/${fname}.bak
+    cp "${EUPS_DIR}/bin/${fname}" "${EUPS_DIR}/bin/${fname}.bak"
+    echo "#!/usr/bin/env python" > "${EUPS_DIR}/bin/${fname}"
+    tail -n +1 "${EUPS_DIR}/bin/${fname}.bak" >> "${EUPS_DIR}/bin/${fname}"
+    chmod 755 "${EUPS_DIR}/bin/${fname}"
+    rm "${EUPS_DIR}/bin/${fname}.bak"
 done
 
 

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -5,20 +5,20 @@
 # see: https://github.com/beckermr/stackvana-core/blob/master/recipe/stackvana_deactivate.sh
 #
 
-get_setup () {
+__eups_get_setup () {
     eups list -s --raw 2>/dev/null \
 	| grep -v '^eups|' | head -1 | cut -d'|' -f1 \
 	|| echo ""
 }
 
 # unsetup any products to keep env clean
-__eups_pkg=$(get_setup)
+__eups_pkg=$(__eups_get_setup)
 while [ -n "$__eups_pkg" ]; do
     unsetup "$__eups_pkg" > /dev/null 2>&1
-    __eups_pkg=$(get_setup)
+    __eups_pkg=$(__eups_get_setup)
 done
 unset __eups_pkg
-
+unset -f __eups_get_setup
 
 # clean out the path, removing EUPS_DIR/bin
 # https://stackoverflow.com/questions/370047/what-is-the-most-elegant-way-to-remove-a-path-from-the-path-variable-in-bash

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -50,12 +50,19 @@ unset -f setup
 if [ "$CONDA_EUPS_BACKUP_setup" ]; then
   eval "$CONDA_EUPS_BACKUP_setup"
   unset CONDA_EUPS_BACKUP_setup
+  __setup_restored=1
 fi
 unset -f unsetup
 if [ "$CONDA_EUPS_BACKUP_unsetup" ]; then
   eval "$CONDA_EUPS_BACKUP_unsetup"
   unset CONDA_EUPS_BACKUP_unsetup
+  __setup_restored=1
 fi
+if [ -n "$EUPS_DIR" ] && [ -z $__setup_restored ]; then
+  # shellcheck disable=SC1091
+  . "${EUPS_DIR}/bin/setups.sh"
+fi
+unset __setup_restored
 
 
 # restoring exisisting python path

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -22,16 +22,16 @@ unset -f __eups_get_setup
 
 # clean out the path, removing EUPS_DIR/bin
 # https://stackoverflow.com/questions/370047/what-is-the-most-elegant-way-to-remove-a-path-from-the-path-variable-in-bash
-# we are not using the function below because this seems to mess with conda's
-# own path manipulations
-WORK=":$PATH:"
-REMOVE=":${EUPS_DIR}/bin:"
-WORK="${WORK//$REMOVE/:}"
-WORK="${WORK%:}"
-WORK="${WORK#:}"
-export PATH="$WORK"
-unset WORK
-unset REMOVE
+# but use sed instead of bash-only regexp parameter substitution
+__EUPS_WORK=":$PATH:"
+__EUPS_REMOVE=":${EUPS_DIR}/bin:"
+# : is a safe regexp delimiter
+__EUPS_WORK=$(echo "$__EUPS_WORK" | sed -e "s:\:$__EUPS_REMOVE\::\::")
+__EUPS_WORK="${__EUPS_WORK%:}"
+__EUPS_WORK="${__EUPS_WORK#:}"
+export PATH="$__EUPS_WORK"
+unset __EUPS_WORK
+unset __EUPS_REMOVE
 
 
 # restore EUPS env variables existing prior to the activation

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=sh
 # Deactivate EUPS
 # 
 # Derived from the stackvana-core recipe by Matt Becker (GitHub @beckermr)
@@ -51,15 +52,15 @@ if [ "$CONDA_EUPS_BACKUP_setup" ]; then
   unset CONDA_EUPS_BACKUP_setup
 fi
 unset -f unsetup
-if [[ "$CONDA_EUPS_BACKUP_unsetup" ]]; then
+if [ "$CONDA_EUPS_BACKUP_unsetup" ]; then
   eval "$CONDA_EUPS_BACKUP_unsetup"
   unset CONDA_EUPS_BACKUP_unsetup
 fi
 
 
 # restoring exisisting python path
-if [[ "${CONDA_EUPS_BACKUP_PYTHONPATH}" ]]; then
-  export PYTHONPATH=${CONDA_EUPS_BACKUP_PYTHONPATH}
+if [ "${CONDA_EUPS_BACKUP_PYTHONPATH}" ]; then
+  export PYTHONPATH="${CONDA_EUPS_BACKUP_PYTHONPATH}"
   unset CONDA_EUPS_BACKUP_PYTHONPATH
 else
   unset PYTHONPATH

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -12,12 +12,12 @@ get_setup () {
 }
 
 # unsetup any products to keep env clean
-pkg=`get_setup`
-while [ -n "$pkg" ]; do
-    unsetup "$pkg" > /dev/null 2>&1
-    pkg=`get_setup`
+__eups_pkg=$(get_setup)
+while [ -n "$__eups_pkg" ]; do
+    unsetup "$__eups_pkg" > /dev/null 2>&1
+    __eups_pkg=$(get_setup)
 done
-unset pkg
+unset __eups_pkg
 
 
 # clean out the path, removing EUPS_DIR/bin
@@ -35,17 +35,17 @@ unset REMOVE
 
 
 # restore EUPS env variables existing prior to the activation
-for var in EUPS_PATH EUPS_SHELL SETUP_EUPS EUPS_DIR; do
-  unset $var
-  bkvar="CONDA_EUPS_BACKUP_$var"
-  eval "value=\"\${$bkvar}\""
-  if [ -n "${value}" ]; then
-    export $var="${value}"
-    unset "$bkvar"
+for __eups_var in EUPS_PATH EUPS_SHELL SETUP_EUPS EUPS_DIR; do
+  unset $__eups_var
+  __eups_bkvar="CONDA_EUPS_BACKUP_$__eups_var"
+  eval "__eups_value=\"\${$__eups_bkvar}\""
+  if [ -n "${__eups_value}" ]; then
+    export $__eups_var="${__eups_value}"
+    unset "$__eups_bkvar"
   fi
 done
-unset bkvar
-unset var
+unset __eups_bkvar
+unset __eups_var
 unset -f setup
 if [ "$CONDA_EUPS_BACKUP_setup" ]; then
   eval "$CONDA_EUPS_BACKUP_setup"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
This PR does three things:

1. The activate and deactivate scripts no longer depend on bash-specific features and syntax.  Since they are sourced in the user's shell, relying on bash is inadvisable.
2. Local variables and functions in the script are given unusual name prefixes to avoid collisions with anything that the user might have or want.  Again, this is because they are sourced in the user's shell, affecting the user's variables unlike normal shell scripts.
3. Because strict-POSIX shells do not provide access to shell function definitions, the `setup` and `unsetup` functions that EUPS defines cannot be restored to their previous values on deactivation.  Instead, we check to see if `EUPS_DIR` is defined in the post-deactivation environment; if it is, we re-source EUPS's `setups.sh` to redefine appropriate `setup` and `unsetup` functions for that environment.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
